### PR TITLE
Disable the reuse of requests in request pool

### DIFF
--- a/request_pool.go
+++ b/request_pool.go
@@ -2,15 +2,21 @@ package tarantool
 
 type cappedRequestPool struct {
 	queue chan *request
+	reuse bool
 }
 
 func newCappedRequestPool() *cappedRequestPool {
 	return &cappedRequestPool{
 		queue: make(chan *request, 1024),
+		reuse: false,
 	}
 }
 
 func (p *cappedRequestPool) Get() (r *request) {
+	if !p.reuse {
+		return &request{}
+	}
+
 	select {
 	case r = <-p.queue:
 		r.opaque = nil
@@ -22,6 +28,10 @@ func (p *cappedRequestPool) Get() (r *request) {
 }
 
 func (p *cappedRequestPool) Put(r *request) {
+	if !p.reuse {
+		return
+	}
+
 	select {
 	case p.queue <- r:
 	default:


### PR DESCRIPTION
Under some weird conditions we're crashing on binpacket.go:23

As a (possibly temporary) workaround, do not store request objects in the shared pool - it was a minor optimization anyway.