### PR TITLE
Clear out possible credentials from RemoteAddr in stable

### DIFF
--- a/connect_test.go
+++ b/connect_test.go
@@ -80,7 +80,7 @@ func TestConnectOptionsDSN(t *testing.T) {
 		{"127.0.0.1/tester%2Ctwo", "", "", "tcp", "127.0.0.1", "tester,two", nil},
 	}
 	for tc, item := range tt {
-		dsn, opts, err := parseOptions(item.uri, nil)
+		dsn, opts, err := parseOptions(item.uri, Options{})
 		assert.Equal(item.err, err, "case %v (err)", tc+1)
 		if err != nil {
 			continue

--- a/connection.go
+++ b/connection.go
@@ -57,13 +57,19 @@ type Connection struct {
 // Connect to tarantool instance with options.
 // Returned Connection could be used to execute queries.
 func Connect(dsnString string, options *Options) (conn *Connection, err error) {
-
-	dsn, opts, err := parseOptions(dsnString, options)
+	var opts Options
+	if options != nil {
+		opts = *options
+	}
+	dsn, opts, err := parseOptions(dsnString, opts)
 	if err != nil {
 		return nil, err
 	}
+	return connect(dsn.Scheme, dsn.Host, opts)
+}
 
-	conn, err = newConn(dsn.Scheme, dsn.Host, opts)
+func connect(scheme, addr string, opts Options) (conn *Connection, err error) {
+	conn, err = newConn(scheme, addr, opts)
 	if err != nil {
 		return
 	}
@@ -203,14 +209,8 @@ func VersionID(major, minor, patch uint32) uint32 {
 	return (((major << 8) | minor) << 8) | patch
 }
 
-func parseOptions(dsnString string, options *Options) (*url.URL, Options, error) {
-	if options == nil {
-		options = &Options{}
-	}
-	opts := *options // copy to new object
-
+func parseOptions(dsnString string, opts Options) (*url.URL, Options, error) {
 	// remove schema, if present
-
 	// === for backward compatibility (only tcp despite of user wishes :)
 	dsnString = strings.TrimPrefix(dsnString, "unix:")
 	// ===
@@ -226,13 +226,6 @@ func parseOptions(dsnString string, options *Options) (*url.URL, Options, error)
 	dsn, err := url.Parse(dsnString)
 	if err != nil {
 		return dsn, opts, err
-	}
-
-	if opts.ConnectTimeout.Nanoseconds() == 0 {
-		opts.ConnectTimeout = DefaultConnectTimeout
-	}
-	if opts.QueryTimeout.Nanoseconds() == 0 {
-		opts.QueryTimeout = DefaultQueryTimeout
 	}
 
 	if len(opts.User) == 0 {
@@ -253,6 +246,13 @@ func parseOptions(dsnString string, options *Options) (*url.URL, Options, error)
 		default:
 			opts.DefaultSpace = path
 		}
+	}
+
+	if opts.ConnectTimeout.Nanoseconds() == 0 {
+		opts.ConnectTimeout = DefaultConnectTimeout
+	}
+	if opts.QueryTimeout.Nanoseconds() == 0 {
+		opts.QueryTimeout = DefaultQueryTimeout
 	}
 
 	return dsn, opts, nil

--- a/connector.go
+++ b/connector.go
@@ -1,41 +1,50 @@
 package tarantool
 
 import (
+	"net/url"
 	"sync"
 )
 
 type Connector struct {
 	sync.Mutex
 	RemoteAddr string
-	options    *Options
+	options    Options
 	conn       *Connection
 }
 
-func New(remoteAddr string, option *Options) *Connector {
-	return &Connector{
-		RemoteAddr: remoteAddr,
-		options:    option,
+// New Connector instance.
+func New(dsnString string, options *Options) *Connector {
+	if options != nil {
+		return &Connector{RemoteAddr: dsnString, options: *options}
 	}
+	return &Connector{RemoteAddr: dsnString}
 }
 
-func (c *Connector) Connect() (*Connection, error) {
-	var err error
-	var conn *Connection
-
+// Connect returns existing connection or will establish another one.
+func (c *Connector) Connect() (conn *Connection, err error) {
 	c.Lock()
+	defer c.Unlock()
+
 	isClosed := c.conn == nil
 	if c.conn != nil {
 		isClosed, _ = c.conn.IsClosed()
 	}
 	if isClosed {
-		c.conn, err = Connect(c.RemoteAddr, c.options)
+		var dsn *url.URL
+		dsn, c.options, err = parseOptions(c.RemoteAddr, c.options)
+		if err != nil {
+			return nil, err
+		}
+		// clear possible user:pass in order to log c.RemoteAddr securely
+		c.RemoteAddr = dsn.Host
+		c.conn, err = connect(dsn.Scheme, dsn.Host, c.options)
 	}
 	conn = c.conn
-	c.Unlock()
 
 	return conn, err
 }
 
+// Close underlying connection.
 func (c *Connector) Close() {
 	c.Lock()
 	isClosed := c.conn == nil

--- a/slave.go
+++ b/slave.go
@@ -49,7 +49,7 @@ func NewSlave(uri string, opts ...Options) (s *Slave, err error) {
 	}
 
 	// it is discussable to connect to instance in instance creation
-	if err = s.connect(uri, &options); err != nil {
+	if err = s.connect(uri, options); err != nil {
 		return nil, err
 	}
 	// prevent from NPE in Next method
@@ -612,7 +612,7 @@ loop:
 }
 
 // connect to tarantool instance (dial + handshake + auth).
-func (s *Slave) connect(uri string, options *Options) (err error) {
+func (s *Slave) connect(uri string, options Options) (err error) {
 	dsn, opts, err := parseOptions(uri, options)
 	if err != nil {
 		return

--- a/slave_test.go
+++ b/slave_test.go
@@ -115,7 +115,7 @@ func TestSlaveConnect(t *testing.T) {
 	require.NoError(err)
 
 	// check
-	err = s.connect(box.Listen, &opts)
+	err = s.connect(box.Listen, opts)
 	require.NoError(err)
 	s.c.stop()
 }


### PR DESCRIPTION
Sanitize dsn string given to the New connector from user/pass
after first Connect call. We can't do it in New itself for
backward compatibility.

(cherry picked from commit 3e5e4df8c878874ba446d55254659f9532bb89dc)