### PR TITLE
Let 1024 bytes snap reader limit be enough for everyone

### DIFF
--- a/lua/tarantool_lastsnapvclock.lua
+++ b/lua/tarantool_lastsnapvclock.lua
@@ -1,5 +1,5 @@
 -- version comment below is used for system.d spec file
--- VERSION = '0.3.2'
+-- VERSION = '0.3.3'
 
 local box = require('box')
 local fio = require('fio')
@@ -59,7 +59,7 @@ local function lastsnapvclock()
     local err
     local data
     local vclock
-    local limit = 255
+    local limit = 1024
 
     local snapfilename = lastsnapfilename()
     if not snapfilename then


### PR DESCRIPTION
In some big clusters vector clock record in snapshot file could be greater than 255 bytes.
The maximum possible length is about 800 bytes. So, 1024 should be enough for everyone :)