### PR TITLE
Replication support for 1.10

### DIFF
--- a/ballot.go
+++ b/ballot.go
@@ -1,0 +1,132 @@
+package tarantool
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+var ErrInvalidBallot = errors.New("Invalid Ballot response")
+
+// Ballot response (in OK) for VoteRequest.
+// Tarantool >= 1.9.0.
+type Ballot struct {
+	RequestID  uint64
+	InstanceID uint32
+
+	ReadOnly bool
+	VClock   VectorClock
+	GCVClock VectorClock
+}
+
+func (p *Ballot) String() string {
+	return fmt.Sprintf("Ballot ReqID:%v Replica:%v, ReadOnly:%v, VClock:%#v, GCVClock:%#v",
+		p.RequestID, p.InstanceID, p.ReadOnly, p.VClock, p.GCVClock)
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler
+func (p *Ballot) UnmarshalBinary(data []byte) (err error) {
+	r := bytes.NewReader(data)
+	if err = p.decodeHeader(r); err != nil {
+		return err
+	}
+
+	if r.Len() == 0 {
+		return nil
+	}
+
+	return p.decodeBody(r)
+}
+
+func (p *Ballot) decodeHeader(r io.Reader) (err error) {
+	var l int
+	d := msgpack.NewDecoder(r)
+	if l, err = d.DecodeMapLen(); err != nil {
+		return
+	}
+	for ; l > 0; l-- {
+		var cd int
+		if cd, err = d.DecodeInt(); err != nil {
+			return
+		}
+		switch cd {
+		case KeySync:
+			if p.RequestID, err = d.DecodeUint64(); err != nil {
+				return
+			}
+		case KeySchemaID:
+			if _, err = d.DecodeUint32(); err != nil {
+				return
+			}
+		case KeyInstanceID:
+			if p.InstanceID, err = d.DecodeUint32(); err != nil {
+				return
+			}
+		default:
+			if err = d.Skip(); err != nil {
+				return
+			}
+		}
+	}
+	return nil
+}
+
+func (p *Ballot) decodeBody(r io.Reader) (err error) {
+	var count int
+
+	d := msgpack.NewDecoder(r)
+	if count, err = d.DecodeMapLen(); err != nil {
+		return
+	}
+
+	for ; count > 0; count-- {
+		var key int
+		if key, err = d.DecodeInt(); err != nil {
+			return
+		}
+		switch key {
+		case KeyBallot:
+			var l int
+			if l, err = d.DecodeMapLen(); err != nil {
+				return
+			}
+
+			if l < 3 {
+				return ErrInvalidBallot
+			}
+
+			if _, err = d.DecodeInt(); err != nil {
+				return err
+			}
+
+			if p.ReadOnly, err = d.DecodeBool(); err != nil {
+				return
+			}
+
+			if _, err = d.DecodeInt(); err != nil {
+				return err
+			}
+
+			if p.VClock, err = decodeVectorClock(d); err != nil {
+				return err
+			}
+
+			if _, err = d.DecodeInt(); err != nil {
+				return err
+			}
+
+			if p.GCVClock, err = decodeVectorClock(d); err != nil {
+				return
+			}
+		default:
+			if err = d.Skip(); err != nil {
+				return
+			}
+		}
+	}
+
+	return
+}

--- a/connect_test.go
+++ b/connect_test.go
@@ -19,7 +19,7 @@ func TestConnect(t *testing.T) {
 	require.NoError(err)
 	defer conn.Close()
 
-	assert.Contains(string(conn.Greeting.Version), "Tarantool")
+	assert.NotEqual(conn.Greeting.Version, 0)
 }
 
 func TestDefaultSpace(t *testing.T) {

--- a/connection.go
+++ b/connection.go
@@ -2,7 +2,9 @@ package tarantool
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/url"
@@ -14,8 +16,10 @@ import (
 )
 
 var (
+	ErrInvalidGreeting   = errors.New("invalid greeting")
 	ErrEmptyDefaultSpace = errors.New("zero-length default space or unnecessary slash in dsn.path")
 	ErrSyncFailed        = errors.New("SYNC failed")
+	versionPrefix        = []byte("Tarantool ")
 )
 
 type Options struct {
@@ -29,7 +33,7 @@ type Options struct {
 }
 
 type Greeting struct {
-	Version []byte
+	Version uint32
 	Auth    []byte
 }
 
@@ -110,21 +114,14 @@ func newConn(scheme, addr string, opts Options) (conn *Connection, err error) {
 		return nil, err
 	}
 
-	greeting := make([]byte, 128)
-
 	connectDeadline := time.Now().Add(opts.ConnectTimeout)
 	conn.tcpConn.SetDeadline(connectDeadline)
 	// removing deadline deferred
 	defer conn.tcpConn.SetDeadline(time.Time{})
 
-	_, err = io.ReadFull(conn.tcpConn, greeting)
+	conn.Greeting, err = parseGreeting(conn.tcpConn)
 	if err != nil {
 		return
-	}
-
-	conn.Greeting = &Greeting{
-		Version: greeting[:64],
-		Auth:    greeting[64:108],
 	}
 
 	// try to authenticate if user have been provided
@@ -167,6 +164,43 @@ func newConn(scheme, addr string, opts Options) (conn *Connection, err error) {
 	}
 
 	return
+}
+
+func parseGreeting(r io.Reader) (*Greeting, error) {
+	greeting := make([]byte, 128)
+
+	_, err := io.ReadFull(r, greeting)
+	if err != nil {
+		return nil, err
+	}
+
+	version, err := parseVersion(greeting[:64])
+	if err != nil {
+		return nil, err
+	}
+
+	return &Greeting{
+		Version: version,
+		Auth:    greeting[64:108],
+	}, nil
+}
+
+func parseVersion(version []byte) (uint32, error) {
+	if !bytes.HasPrefix(version, versionPrefix) {
+		return 0, ErrInvalidGreeting
+	}
+
+	var major, minor, patch uint32
+	str := string(version[len(versionPrefix):])
+	if n, _ := fmt.Sscanf(str, "%d.%d.%d", &major, &minor, &patch); n != 3 {
+		return 0, ErrInvalidGreeting
+	}
+
+	return VersionID(major, minor, patch), nil
+}
+
+func VersionID(major, minor, patch uint32) uint32 {
+	return (((major << 8) | minor) << 8) | patch
 }
 
 func parseOptions(dsnString string, options *Options) (*url.URL, Options, error) {

--- a/const.go
+++ b/const.go
@@ -18,6 +18,7 @@ const (
 	PingRequest      = 64
 	JoinCommand      = 65
 	SubscribeRequest = 66
+	VoteRequest      = 68 // Tarantool >= 1.9.0
 	ErrorFlag        = 0x8000
 )
 
@@ -44,6 +45,7 @@ const (
 	KeyDefTuple       = 0x28
 	KeyData           = 0x30
 	KeyError          = 0x31
+	KeyBallot         = 0x29 // Tarantool >= 1.9.0
 )
 
 const (
@@ -204,4 +206,11 @@ const (
 
 const (
 	ServerIdent = "Tarantool 1.6.8 (Binary)"
+)
+
+// Consts for Tarantool features which require version check
+const (
+	version1_7_0 = uint32(67328) // VersionID(1, 7, 0)
+	version1_7_7 = uint32(67335) // VersionID(1, 7, 7)
+	version1_9_0 = uint32(67840) // VersionID(1, 9, 0)
 )

--- a/result.go
+++ b/result.go
@@ -59,7 +59,13 @@ func (r *Result) pack(requestID uint32) (*packedPacket, error) {
 func (r *Result) unpack(rr io.Reader) (err error) {
 	var l int
 	d := msgpack.NewDecoder(rr)
-	if l, err = d.DecodeMapLen(); err != nil {
+
+	// Tarantool >= 1.7.7 sends periodic heartbeat messages without body
+	if l, err = d.DecodeMapLen(); err == io.EOF && r.ErrorCode == OkCode {
+		return nil
+	}
+
+	if err != nil {
 		return
 	}
 	for ; l > 0; l-- {

--- a/vote.go
+++ b/vote.go
@@ -1,0 +1,18 @@
+package tarantool
+
+import "io"
+
+// VoteRequest which we send to master before Join in Tarantool >= 1.9.0
+type Vote struct{}
+
+var _ Query = (*Vote)(nil)
+
+// Pack implements a part of the Query interface
+func (q *Vote) Pack(data *packData, w io.Writer) (uint32, error) {
+	return VoteRequest, nil
+}
+
+// Unpack implements a part of the Query interface
+func (q *Vote) Unpack(r io.Reader) (err error) {
+	return ErrNotSupported
+}


### PR DESCRIPTION
Added replication support for Tarantool 1.10 and below. 
Work still in progress, so I just want to code review from @rkravchik and @viciious.

Difference between 1.6 and 1.10:

**Vote request before JOIN**
Before JOIN request slave sends Vote request and processes Ballot response from master

**JOIN has two stages**
JOIN:
1. Receive data stored in snapshot file
2. Get OK response from master

Final JOIN:
1. Receive data that didn't processed to snapshot yet
2. Get OK response from master

More details: 
https://github.com/tarantool/tarantool/blob/1.10/src/box/applier.cc#L280

**Slave and Master send Heartbeat messages to each other**
Master message is just OK response without body.
Slave message should contain current vclock.

More details:
https://github.com/tarantool/tarantool/blob/1.10/src/box/applier.cc#L118

What left:

- [x] Reconnect
- [x] Tests
- [x] Check correct replication with few replicas at the same time