### PR TITLE
Bugfix for tarantools above 1.7.0 but below 1.7.7

### DIFF
--- a/slave.go
+++ b/slave.go
@@ -219,7 +219,7 @@ func (s *Slave) Subscribe(lsns ...int64) (it PacketIterator, err error) {
 	s.next = s.nextXlog
 
 	// Tarantool >= 1.7.7 sends periodic heartbeat messages
-	if s.Version() < version1_7_7 {
+	if s.Version() < version1_7_0 {
 		return s, nil
 	}
 
@@ -578,7 +578,7 @@ func (s *Slave) nextEOF() (*Packet, error) {
 
 // for Tarantool >= 1.7.7 heartbeat sends encoded vclock to master every second
 func (s *Slave) heartbeat() {
-	if s.Version() < version1_7_7 {
+	if s.Version() < version1_7_0 {
 		return
 	}
 


### PR DESCRIPTION
All replicas which work with tarantools above or equal version 1.7.0 must send heartbeat to master. Before commit it worked only for tarantools above 1.7.7 which caused "timed out" error from master if its version was below 1.7.7 but above 1.7.0