### PR TITLE
Dependency update: satori/go.uuid to gofrs/uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/viciious/go-tarantool
 go 1.16
 
 require (
+	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/klauspost/compress v1.11.3
 	github.com/philhofer/fwd v1.0.0 // indirect
-	github.com/satori/go.uuid v1.2.0
 	github.com/stretchr/testify v1.6.2-0.20201103103935-92707c0b2d50
 	github.com/tinylib/msgp v1.0.3-0.20180215042507-3b5c87ab5fb0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
+github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/klauspost/compress v1.11.3 h1:dB4Bn0tN3wdCzQxnS8r06kV74qN/TAfaIS0bVE8h3jc=
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/philhofer/fwd v1.0.0 h1:UbZqGr5Y38ApvM/V/jEljVxwocdweyH+vmYvRPBnbqQ=

--- a/slave.go
+++ b/slave.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/viciious/go-tarantool/typeconv"
 )
 
@@ -61,9 +61,12 @@ func NewSlave(uri string, opts ...Options) (s *Slave, err error) {
 }
 
 func (s *Slave) parseOptions(uri string, options Options) (err error) {
-
 	if len(options.UUID) == 0 {
-		s.UUID = uuid.NewV1().String()
+		uuid, err := uuid.NewV1()
+		if err != nil {
+			return err
+		}
+		s.UUID = uuid.String()
 	} else {
 		s.UUID = options.UUID
 	}


### PR DESCRIPTION
Dependency library github.com/satori/go.uuid contains security finding and is not updated long time: https://github.com/satori/go.uuid/issues/115

Dependency updated to use https://github.com/gofrs/uuid