### PR TITLE
Fix index field description parsing

### DIFF
--- a/connect_test.go
+++ b/connect_test.go
@@ -22,6 +22,31 @@ func TestConnect(t *testing.T) {
 	assert.NotEqual(conn.greeting.Version, 0)
 }
 
+func TestMapIndexDescription(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	config := `
+	local s = box.schema.space.create('tester', {id = 42})
+	s:create_index('tester_id', {
+		parts = {
+        	{field = 1, type = 'number', is_nullable = false},
+    	},
+	})
+	local t = s:insert({1})
+	`
+	box, err := NewBox(config, nil)
+	require.NoError(err)
+	defer box.Close()
+
+	conn, err := Connect(box.Addr(), nil)
+	require.NoError(err)
+	defer conn.Close()
+
+	pkFields, ok := conn.GetPrimaryKeyFields("tester")
+	require.True(ok)
+	assert.ElementsMatch(pkFields, []int{0})
+}
+
 func TestDefaultSpace(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/connection.go
+++ b/connection.go
@@ -379,9 +379,16 @@ func (conn *Connection) pullSchema() (err error) {
 			if unique, ok := indexAttr["unique"]; ok && unique.(bool) {
 				pk := make([]int, len(indexFields))
 				for i := range indexFields {
-					descr := indexFields[i].([]interface{})
-					f, _ := conn.packData.fieldNo(descr[0])
-					pk[i] = int(f)
+					switch descr := indexFields[i].(type) {
+					case []interface{}:
+						f, _ := conn.packData.fieldNo(descr[0])
+						pk[i] = int(f)
+					case map[string]interface{}:
+						f, _ := conn.packData.fieldNo(descr["field"])
+						pk[i] = int(f)
+					default:
+						panic("invalid index field format")
+					}
 				}
 				conn.packData.primaryKeyMap[spaceID] = pk
 			}


### PR DESCRIPTION
The schema parsing logic relies on the fact that index field description is always an array. But it may also be a map.
This PR fixes that.

Example:
```lua
box.cfg { listen = 3301 }
box.schema.user.grant('guest', 'super', nil, nil, { if_not_exists = true })

local space = box.schema.create_space('some_space', { if_not_exists = true })
local index = space:create_index('primary', {
    if_not_exists = true,
    parts = {
        { field = 1, type = 'string', is_nullable = false },
    },
})

local format = box.space[289]:select { space.id, index.id }
print(require('yaml').encode(format))
```

```go
package main

import (
	"github.com/viciious/go-tarantool"
	"log"
)

func main() {
	_, err := tarantool.Connect("guest@localhost:3301", &tarantool.Options{})
	if err != nil {
		log.Fatalln(err)
	}
}
```

This code will cause such error:
```
panic: interface conversion: interface {} is map[string]interface {}, not []interface {}

goroutine 1 [running]:
github.com/viciious/go-tarantool.(*Connection).pullSchema(0xc000120000)
        /Users/o.utkin/go/pkg/mod/github.com/viciious/go-tarantool@v0.0.0-20220525112527-ba97bae22168/connection.go:382 +0x50e
github.com/viciious/go-tarantool.connect({0x121fcd8?, 0xc0000c8008?}, {0xc0000dc120?, 0x0?}, {0xc0000dc12c?, 0x5?}, {0x3b9aca00, 0x3b9aca00, {0x0, 0x0}, ...})
        /Users/o.utkin/go/pkg/mod/github.com/viciious/go-tarantool@v0.0.0-20220525112527-ba97bae22168/connection.go:100 +0xe5
github.com/viciious/go-tarantool.ConnectContext({0x121fcd8, 0xc0000c8008}, {0x11ca4b5?, 0x10403f1?}, 0xc0ffffffff?)
        /Users/o.utkin/go/pkg/mod/github.com/viciious/go-tarantool@v0.0.0-20220525112527-ba97bae22168/connection.go:82 +0x20e
github.com/viciious/go-tarantool.Connect(...)
        /Users/o.utkin/go/pkg/mod/github.com/viciious/go-tarantool@v0.0.0-20220525112527-ba97bae22168/connection.go:87
main.main()
        /xxx/cmd/replicationinfo/main.go:9 +0x77
```

