### PR TITLE
feat: support 64-bit schema version

### DIFF
--- a/binpacket.go
+++ b/binpacket.go
@@ -37,7 +37,7 @@ func (pp *BinaryPacket) WriteTo(w io.Writer) (n int64, err error) {
 	h = msgp.AppendUint64(h, pp.packet.requestID)
 	if pp.packet.SchemaID != 0 {
 		h = msgp.AppendUint(h, KeySchemaID)
-		h = msgp.AppendUint32(h, pp.packet.SchemaID)
+		h = msgp.AppendUint64(h, pp.packet.SchemaID)
 	}
 
 	l := len(h) + len(body)

--- a/packet.go
+++ b/packet.go
@@ -11,7 +11,7 @@ type Packet struct {
 	Cmd        uint
 	LSN        uint64
 	requestID  uint64
-	SchemaID   uint32
+	SchemaID   uint64
 	InstanceID uint32
 	Timestamp  time.Time
 	Request    Query
@@ -62,7 +62,7 @@ func (pack *Packet) UnmarshalBinaryHeader(data []byte) (buf []byte, err error) {
 				return
 			}
 		case KeySchemaID:
-			if pack.SchemaID, buf, err = msgp.ReadUint32Bytes(buf); err != nil {
+			if pack.SchemaID, buf, err = msgp.ReadUint64Bytes(buf); err != nil {
 				return
 			}
 		case KeyLSN:

--- a/server.go
+++ b/server.go
@@ -31,7 +31,7 @@ type IprotoServer struct {
 	closeOnce  sync.Once
 	firstError error
 	perf       PerfCount
-	schemaID   uint32
+	schemaID   uint64
 }
 
 type IprotoServerOptions struct {

--- a/vclock.go
+++ b/vclock.go
@@ -78,7 +78,7 @@ func (p *VClock) UnmarshalBinaryHeader(data []byte) (buf []byte, err error) {
 				return
 			}
 		case KeySchemaID:
-			if _, buf, err = msgp.ReadUint32Bytes(buf); err != nil {
+			if _, buf, err = msgp.ReadUint64Bytes(buf); err != nil {
 				return
 			}
 		case KeyInstanceID:


### PR DESCRIPTION
Tarantool master branch introduced the 64-bit schema version ([one](https://github.com/tarantool/tarantool/commit/0b876b7600677a7b726a2fd8e2e3c303bc7a1cde), [two](https://github.com/tarantool/tarantool/pull/8435)). Current PR adds 64-bit support for go-tarantool as well.