### PR TITLE
Add global data pool

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -104,6 +104,9 @@ func connect(ctx context.Context, scheme, addr string, opts Options) (conn *Conn
 		return
 	}
 
+	// store or fetch uniq instance of packdata in the global pool
+	conn.packData = globalPackDataPool.Put(conn.packData)
+
 	// remove deadline
 	conn.tcpConn.SetDeadline(time.Time{})
 


### PR DESCRIPTION
Storage schema generates a lot small objects when connected to multiple tarantool instances and generates additional pressure on the GC