### PR TITLE
Cap pool packet size

### DIFF
--- a/binpacket.go
+++ b/binpacket.go
@@ -66,7 +66,7 @@ func (pp *BinaryPacket) Reset() {
 }
 
 func (pp *BinaryPacket) Release() {
-	if pp.pool != nil {
+	if pp.pool != nil && cap(pp.body) <= DefaultMaxPoolPacketSize {
 		pp.pool.Put(pp)
 	}
 }

--- a/binpacket_pool.go
+++ b/binpacket_pool.go
@@ -6,7 +6,7 @@ type BinaryPacketPool struct {
 
 func newBinaryPacketPool() *BinaryPacketPool {
 	return &BinaryPacketPool{
-		queue: make(chan *BinaryPacket, 1024),
+		queue: make(chan *BinaryPacket, 4096),
 	}
 }
 

--- a/defaults.go
+++ b/defaults.go
@@ -13,4 +13,6 @@ const (
 var (
 	DefaultReaderBufSize = 128 * 1024
 	DefaultWriterBufSize = 4 * 1024
+
+	DefaultMaxPoolPacketSize = 64 * 1024
 )


### PR DESCRIPTION
Cap the maximum size of a binary packet returned to the pool