### PR TITLE
Fix wrong marshalling for call* & eval responses

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
   build:
     name: Test Go ${{ matrix.go-version }} / Tarantool ${{ matrix.tarantool-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # See https://github.com/Dart-Code/Dart-Code/pull/2375
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:

--- a/binpacket.go
+++ b/binpacket.go
@@ -58,6 +58,7 @@ func (pp *BinaryPacket) Reset() {
 	pp.packet.SchemaID = 0
 	pp.packet.requestID = 0
 	pp.packet.Result = nil
+	pp.packet.ResultUnmarshalMode = ResultDefaultMode
 	pp.body = pp.body[:0]
 }
 

--- a/call17_test.go
+++ b/call17_test.go
@@ -141,7 +141,7 @@ func TestCall17(t *testing.T) {
 		}
 		res := conn.Exec(context.Background(), params.query, opts...)
 
-		if assert.NoError(err) {
+		if assert.NoError(res.Error) {
 			assert.Equal(params.expectedData, res.Data)
 			assert.Equal(params.expectedRawData, res.RawData)
 		}

--- a/call17_test.go
+++ b/call17_test.go
@@ -14,7 +14,7 @@ func TestCall17(t *testing.T) {
 	tarantoolConfig := `
     local s = box.schema.space.create('tester', {id = 42})
     s:create_index('tester_id', {
-        type = 'hash',
+        type = 'tree',
         parts = {1, 'NUM'}
     })
     s:create_index('tester_name', {
@@ -31,7 +31,7 @@ func TestCall17(t *testing.T) {
     t = s:insert({3, 'Length', 93})
     
     function sel_all()
-        return box.space.tester:select{}
+        return box.space.tester:select({}, {iterator = "ALL"})
     end
 
     function sel_name(tester_id, name)

--- a/call_test.go
+++ b/call_test.go
@@ -104,7 +104,7 @@ func TestCall(t *testing.T) {
 		}
 		res := conn.Exec(context.Background(), params.query, opts...)
 
-		if assert.NoError(err) {
+		if assert.NoError(res.Error) {
 			assert.Equal(params.expectedData, res.Data)
 			assert.Equal(params.expectedRawData, res.RawData)
 		}

--- a/call_test.go
+++ b/call_test.go
@@ -1,6 +1,7 @@
 package tarantool
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,11 +16,11 @@ func TestCall(t *testing.T) {
         type = 'hash',
         parts = {1, 'NUM'}
     })
-	s:create_index('tester_name', {
+    s:create_index('tester_name', {
         type = 'hash',
         parts = {2, 'STR'}
     })
-	s:create_index('id_name', {
+    s:create_index('id_name', {
         type = 'hash',
         parts = {1, 'NUM', 2, 'STR'},
         unique = true
@@ -36,11 +37,31 @@ func TestCall(t *testing.T) {
         return box.space.tester.index.id_name:select{tester_id, name}
     end
 
+    function call_case_1()
+        return 1
+    end
+
+    function call_case_2()
+        return 1, 2, 3
+    end
+
+    function call_case_3()
+        return
+    end
+
+    local number_of_extra_cases = 3
+
     box.schema.func.create('sel_all', {if_not_exists = true})
     box.schema.func.create('sel_name', {if_not_exists = true})
+    for i = 1, number_of_extra_cases do
+        box.schema.func.create('call_case_'..i, {if_not_exists = true})
+    end
 
     box.schema.user.grant('guest', 'execute', 'function', 'sel_all', {if_not_exists = true})
-    box.schema.user.grant('guest', 'execute', 'function', 'sel_name', {if_not_exists = true})    
+    box.schema.user.grant('guest', 'execute', 'function', 'sel_name', {if_not_exists = true})
+    for i = 1, number_of_extra_cases do
+        box.schema.user.grant('guest', 'execute', 'function', 'call_case_'..i, {if_not_exists = true})
+    end
     `
 
 	box, err := NewBox(tarantoolConfig, nil)
@@ -49,57 +70,190 @@ func TestCall(t *testing.T) {
 	}
 	defer box.Close()
 
-	do := func(connectOptions *Options, query *Call, expected [][]interface{}) {
+	type testParams struct {
+		query           *Call
+		execOption      ExecOption
+		expectedData    [][]interface{}
+		expectedRawData interface{}
+	}
+
+	do := func(params *testParams) {
 		var buf []byte
 
-		conn, err := box.Connect(connectOptions)
+		conn, err := box.Connect(nil)
 		assert.NoError(err)
 		assert.NotNil(conn)
 
 		defer conn.Close()
 
-		buf, err = query.MarshalMsg(nil)
+		buf, err = params.query.MarshalMsg(nil)
 
 		if assert.NoError(err) {
 			var query2 = &Call{}
 			_, err = query2.UnmarshalMsg(buf)
 
 			if assert.NoError(err) {
-				assert.Equal(query.Name, query2.Name)
-				assert.Equal(query.Tuple, query2.Tuple)
+				assert.Equal(params.query.Name, query2.Name)
+				assert.Equal(params.query.Tuple, query2.Tuple)
 			}
 		}
 
-		data, err := conn.Execute(query)
+		var opts []ExecOption
+		if params.execOption != nil {
+			opts = append(opts, params.execOption)
+		}
+		res := conn.Exec(context.Background(), params.query, opts...)
 
 		if assert.NoError(err) {
-			assert.Equal(expected, data)
+			assert.Equal(params.expectedData, res.Data)
+			assert.Equal(params.expectedRawData, res.RawData)
 		}
 	}
 
 	// call sel_all without params
-	do(nil,
-		&Call{
+	do(&testParams{
+		query: &Call{
 			Name: "sel_all",
 		},
-		[][]interface{}{
+		expectedData: [][]interface{}{
 			{int64(1), "First record"},
 			{int64(2), "Music"},
 			{int64(3), "Length", int64(93)},
 		},
-	)
+	})
+	do(&testParams{
+		query: &Call{
+			Name: "sel_all",
+		},
+		execOption: ExecResultAsDataWithFallback,
+		expectedData: [][]interface{}{
+			{int64(1), "First record"},
+			{int64(2), "Music"},
+			{int64(3), "Length", int64(93)},
+		},
+	})
+	do(&testParams{
+		query: &Call{
+			Name: "sel_all",
+		},
+		execOption: ExecResultAsRawData,
+		expectedRawData: []interface{}{
+			[]interface{}{int64(1), "First record"},
+			[]interface{}{int64(2), "Music"},
+			[]interface{}{int64(3), "Length", int64(93)},
+		},
+	})
 
 	// call sel_name with params
-	do(nil,
-		&Call{
+	do(&testParams{
+		query: &Call{
 			Name:  "sel_name",
 			Tuple: []interface{}{int64(2), "Music"},
 		},
-		[][]interface{}{
+		expectedData: [][]interface{}{
 			{int64(2), "Music"},
 		},
-	)
+	})
+	do(&testParams{
+		query: &Call{
+			Name:  "sel_name",
+			Tuple: []interface{}{int64(2), "Music"},
+		},
+		execOption: ExecResultAsDataWithFallback,
+		expectedData: [][]interface{}{
+			{int64(2), "Music"},
+		},
+	})
+	do(&testParams{
+		query: &Call{
+			Name:  "sel_name",
+			Tuple: []interface{}{int64(2), "Music"},
+		},
+		execOption: ExecResultAsRawData,
+		expectedRawData: []interface{}{
+			[]interface{}{int64(2), "Music"},
+		},
+	})
 
+	// scalar 1
+	do(&testParams{
+		query: &Call{
+			Name: "call_case_1",
+		},
+		expectedData: [][]interface{}{
+			{int64(1)},
+		},
+	})
+	do(&testParams{
+		query: &Call{
+			Name: "call_case_1",
+		},
+		execOption: ExecResultAsDataWithFallback,
+		expectedData: [][]interface{}{
+			{int64(1)},
+		},
+	})
+	do(&testParams{
+		query: &Call{
+			Name: "call_case_1",
+		},
+		execOption: ExecResultAsRawData,
+		expectedRawData: []interface{}{
+			[]interface{}{int64(1)},
+		},
+	})
+
+	// multiple scalars
+	do(&testParams{
+		query: &Call{
+			Name: "call_case_2",
+		},
+		expectedData: [][]interface{}{
+			{int64(1)}, {int64(2)}, {int64(3)},
+		},
+	})
+	do(&testParams{
+		query: &Call{
+			Name: "call_case_2",
+		},
+		execOption: ExecResultAsDataWithFallback,
+		expectedData: [][]interface{}{
+			{int64(1)}, {int64(2)}, {int64(3)},
+		},
+	})
+	do(&testParams{
+		query: &Call{
+			Name: "call_case_2",
+		},
+		execOption: ExecResultAsRawData,
+		expectedRawData: []interface{}{
+			[]interface{}{int64(1)},
+			[]interface{}{int64(2)},
+			[]interface{}{int64(3)},
+		},
+	})
+
+	// empty result
+	do(&testParams{
+		query: &Call{
+			Name: "call_case_3",
+		},
+		expectedData: [][]interface{}{},
+	})
+	do(&testParams{
+		query: &Call{
+			Name: "call_case_3",
+		},
+		execOption:   ExecResultAsDataWithFallback,
+		expectedData: [][]interface{}{},
+	})
+	do(&testParams{
+		query: &Call{
+			Name: "call_case_3",
+		},
+		execOption:      ExecResultAsRawData,
+		expectedRawData: []interface{}{},
+	})
 }
 
 func BenchmarkCallPack(b *testing.B) {

--- a/call_test.go
+++ b/call_test.go
@@ -13,7 +13,7 @@ func TestCall(t *testing.T) {
 	tarantoolConfig := `
     local s = box.schema.space.create('tester', {id = 42})
     s:create_index('tester_id', {
-        type = 'hash',
+        type = 'tree',
         parts = {1, 'NUM'}
     })
     s:create_index('tester_name', {
@@ -30,7 +30,7 @@ func TestCall(t *testing.T) {
     t = s:insert({3, 'Length', 93})
     
     function sel_all()
-        return box.space.tester:select{}
+        return box.space.tester:select({}, {iterator = "ALL"})
     end
 
     function sel_name(tester_id, name)

--- a/connection.go
+++ b/connection.go
@@ -609,8 +609,11 @@ READER_LOOP:
 			conn.perf.QueryComplete(req.opaque, time.Since(req.startedAt))
 		}
 
+		pp.packet.ResultUnmarshalMode = req.resultMode
+		res := AsyncResult{0, nil, pp, conn, req.opaque}
+
 		select {
-		case req.replyChan <- &AsyncResult{0, nil, pp, conn, req.opaque}:
+		case req.replyChan <- &res:
 			pp = nil
 		default:
 		}

--- a/eval_test.go
+++ b/eval_test.go
@@ -1,6 +1,7 @@
 package tarantool
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -44,14 +45,21 @@ func TestEvalExecute(t *testing.T) {
 	tnt, err := Connect(box.Listen, &Options{})
 	require.NoError(err)
 
-	res, err := tnt.Execute(q)
+	data, err := tnt.Execute(q)
 	require.NoError(err)
-	require.Len(res, 5)
-	assert.EqualValues(box.Listen, res[0][0])
-	assert.EqualValues(user, res[1][0])
-	assert.EqualValues(args[0], res[2][0])
-	assert.EqualValues(args[1], res[3][0])
-	assert.EqualValues(args, res[4])
+	require.Len(data, 5)
+	assert.EqualValues(box.Listen, data[0][0])
+	assert.EqualValues(user, data[1][0])
+	assert.EqualValues(args[0], data[2][0])
+	assert.EqualValues(args[1], data[3][0])
+	assert.EqualValues(args, data[4])
+
+	res := tnt.Exec(context.Background(), q, ExecResultAsDataWithFallback)
+	require.NoError(res.Error)
+	require.Nil(res.Data)
+	assert.Equal(res.RawData, []interface{}{
+		box.Listen, user, args[0], args[1], args,
+	})
 }
 
 func BenchmarkEvalPack(b *testing.B) {

--- a/execute.go
+++ b/execute.go
@@ -140,6 +140,7 @@ func (conn *Connection) Exec(ctx context.Context, q Query, options ...ExecOption
 
 	request := requestPool.Get()
 	request.replyChan = replyChan
+	request.resultMode = conn.resultUnmarshalMode // could also by overwritten by options
 	for i := 0; i < len(options); i++ {
 		options[i].apply(request)
 	}
@@ -195,6 +196,7 @@ func (conn *Connection) ExecAsync(
 	request := requestPool.Get()
 	request.opaque = opaque
 	request.replyChan = replyChan
+	request.resultMode = conn.resultUnmarshalMode // could also by overwritten by options
 	for i := 0; i < len(options); i++ {
 		options[i].apply(request)
 	}
@@ -206,6 +208,6 @@ func (conn *Connection) ExecAsync(
 }
 
 func (conn *Connection) Execute(q Query) ([][]interface{}, error) {
-	res := conn.Exec(context.Background(), q)
+	res := conn.Exec(context.Background(), q, ResultModeExecOption(ResultDefaultMode))
 	return res.Data, res.Error
 }

--- a/packet.go
+++ b/packet.go
@@ -16,6 +16,8 @@ type Packet struct {
 	Timestamp  time.Time
 	Request    Query
 	Result     *Result
+
+	ResultUnmarshalMode resultUnmarshalMode
 }
 
 func (pack *Packet) String() string {
@@ -101,7 +103,7 @@ func (pack *Packet) UnmarshalBinaryBody(data []byte) (buf []byte, err error) {
 
 	unpackr := func(errorCode uint, data []byte) (buf []byte, err error) {
 		buf = data
-		res := &Result{ErrorCode: errorCode}
+		res := &Result{ErrorCode: errorCode, unmarshalMode: pack.ResultUnmarshalMode}
 		if buf, err = res.UnmarshalMsg(buf); err != nil {
 			return
 		}
@@ -128,7 +130,7 @@ func (pack *Packet) UnmarshalBinary(data []byte) error {
 
 // UnmarshalMsg implements msgp.Unmarshaler
 func (pack *Packet) UnmarshalMsg(data []byte) (buf []byte, err error) {
-	*pack = Packet{}
+	*pack = Packet{ResultUnmarshalMode: pack.ResultUnmarshalMode}
 
 	buf = data
 

--- a/request_pool.go
+++ b/request_pool.go
@@ -21,6 +21,7 @@ func (p *cappedRequestPool) Get() (r *request) {
 	case r = <-p.queue:
 		r.opaque = nil
 		r.replyChan = nil
+		r.resultMode = ResultDefaultMode
 	default:
 		r = &request{}
 	}

--- a/result_test.go
+++ b/result_test.go
@@ -1,0 +1,63 @@
+package tarantool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResultMarshaling(t *testing.T) {
+	// The result of a call17 to:
+	// function a()
+	//     return "a"
+	// end
+	tntBodyBytes := []byte{
+		0x81,                     // MP_MAP
+		0x30,                     // key IPROTO_DATA
+		0xdd, 0x0, 0x0, 0x0, 0x1, // MP_ARRAY
+		0xa1, 0x61, // string value "a"
+	}
+
+	expectedDefaultMarshalBytes := []byte{
+		0x81,       // MP_MAP
+		0x30,       // key IPROTO_DATA
+		0x91,       // MP_ARRAY
+		0x91,       // MP_ARRAY
+		0xa1, 0x61, // string value "a"
+	}
+
+	expectedFallbackMarshalBytes := []byte{
+		0x81,       // MP_MAP
+		0x30,       // key IPROTO_DATA
+		0x91,       // MP_ARRAY
+		0xa1, 0x61, // string value "a"
+	}
+
+	var result Result
+
+	buf, err := result.UnmarshalMsg(tntBodyBytes)
+	require.NoError(t, err, "error unmarshaling result")
+	require.Empty(t, buf, "unmarshaling result buffer is not empty")
+	require.Equal(t, result.Data, [][]interface{}{{"a"}})
+	require.Empty(t, result.RawData)
+
+	defaultMarshalRes, err := result.MarshalMsg(nil)
+	require.NoError(t, err, "error marshaling by default marshaller")
+	require.Equal(
+		t,
+		expectedDefaultMarshalBytes,
+		defaultMarshalRes,
+	)
+
+	result = Result{unmarshalMode: ResultAsDataWithFallback}
+
+	buf, err = result.UnmarshalMsg(tntBodyBytes)
+	require.NoError(t, err, "error unmarshaling result")
+	require.Empty(t, buf, "unmarshaling result buffer is not empty")
+	require.Empty(t, result.Data)
+	require.Equal(t, result.RawData, []interface{}{"a"})
+
+	fallbackMarshalRes, err := result.MarshalMsg(nil)
+	require.NoError(t, err, "error marshaling by bytes marshaller")
+	require.Equal(t, fallbackMarshalRes, expectedFallbackMarshalBytes)
+}

--- a/select_test.go
+++ b/select_test.go
@@ -12,11 +12,11 @@ func TestSelect(t *testing.T) {
 	tarantoolConfig := `
     local s = box.schema.space.create('tester', {id = 42})
     s:create_index('tester_id', {
-        type = 'hash',
+        type = 'tree',
         parts = {1, 'NUM'}
     })
 	s:create_index('tester_name', {
-        type = 'hash',
+        type = 'tree',
         parts = {2, 'STR'}
     })
 	s:create_index('id_name', {
@@ -158,9 +158,9 @@ func TestSelect(t *testing.T) {
 			Iterator: IterAll,
 		},
 		[][]interface{}{
-			{int64(2), "Music"},
-			{int64(3), "Length", int64(93)},
 			{int64(1), "First record"},
+			{int64(3), "Length", int64(93)},
+			{int64(2), "Music"},
 		},
 	)
 	// iterate Eq using STR index

--- a/tnt.go
+++ b/tnt.go
@@ -17,10 +17,11 @@ func init() {
 }
 
 type request struct {
-	opaque    interface{}
-	replyChan chan *AsyncResult
-	packet    *BinaryPacket
-	startedAt time.Time
+	opaque     interface{}
+	replyChan  chan *AsyncResult
+	packet     *BinaryPacket
+	startedAt  time.Time
+	resultMode resultUnmarshalMode
 }
 
 type QueryCompleteFn func(interface{}, time.Duration)


### PR DESCRIPTION
# The problem 
The array of bytes we get after marshalling of `*Result` might be different from original sequence of bytes it was umarshalled from. This the case at least for call* and eval responses if they return scalar or array of scalars. This happens because:
- The documentation specifies response data as an MP_OBJECT:
https://www.tarantool.io/en/doc/2.11/dev_guide/internals/iproto/requests/#iproto-call
- Instead the library always expects it to be an array of tuples and forcefully wraps it :
https://github.com/viciious/go-tarantool/blob/6f8008d58c9e26f9c7bd2a50886350ee34c016a0/result.go#L86

