### PR TITLE
Iproto Server panics on pings

### DIFF
--- a/server.go
+++ b/server.go
@@ -16,6 +16,8 @@ const saltSize = 32
 type QueryHandler func(queryContext context.Context, query Query) *Result
 type OnShutdownCallback func(err error)
 
+func defaultPingStatus(*IprotoServer) uint { return OKCommand }
+
 type IprotoServer struct {
 	sync.Mutex
 	conn          net.Conn
@@ -43,13 +45,14 @@ type IprotoServerOptions struct {
 
 func NewIprotoServer(uuid string, handler QueryHandler, onShutdown OnShutdownCallback) *IprotoServer {
 	return &IprotoServer{
-		conn:       nil,
-		reader:     nil,
-		writer:     nil,
-		handler:    handler,
-		onShutdown: onShutdown,
-		uuid:       uuid,
-		schemaID:   1,
+		conn:          nil,
+		reader:        nil,
+		writer:        nil,
+		handler:       handler,
+		onShutdown:    onShutdown,
+		uuid:          uuid,
+		schemaID:      1,
+		getPingStatus: defaultPingStatus,
 	}
 }
 
@@ -58,9 +61,8 @@ func (s *IprotoServer) WithOptions(opts *IprotoServerOptions) *IprotoServer {
 		opts = &IprotoServerOptions{}
 	}
 	s.perf = opts.Perf
-	s.getPingStatus = opts.GetPingStatus
-	if s.getPingStatus == nil {
-		s.getPingStatus = func(*IprotoServer) uint { return 0 }
+	if opts.GetPingStatus != nil {
+		s.getPingStatus = opts.GetPingStatus
 	}
 	return s
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,44 @@
+package tarantool
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerPing(t *testing.T) {
+	handler := func(queryContext context.Context, query Query) *Result {
+		return &Result{}
+	}
+
+	s := NewIprotoServer("1", handler, nil)
+
+	listenAddr := make(chan string)
+	go func() {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer ln.Close()
+
+		listenAddr <- ln.Addr().String()
+		close(listenAddr)
+
+		conn, err := ln.Accept()
+		require.NoError(t, err)
+
+		s.Accept(conn)
+	}()
+
+	addr := <-listenAddr
+	conn, err := Connect(addr, nil)
+	require.NoError(t, err)
+
+	res := conn.Exec(context.Background(), &Ping{})
+	assert.Equal(t, res.ErrorCode, OKCommand)
+	assert.NoError(t, res.Error)
+
+	conn.Close()
+	s.Shutdown()
+}


### PR DESCRIPTION
After changes in the [commit](https://github.com/viciious/go-tarantool/commit/091e42b55ae03f89927236e0d68d7272849f8499) IprotoServer now panics on pings if method WithOption is not called explicitly. Earlier it was enough to create it with constructor to work properly.  